### PR TITLE
Add AVIF MIME type support to mimetype definitions

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -41,6 +41,7 @@ mimetypes.add_type('application/javascript', '.js')
 
 # Likewise, add explicit content-type header for certain missing image types
 mimetypes.add_type('image/webp', '.webp')
+mimetypes.add_type('image/avif', '.avif')
 
 if not cmd_opts.share and not cmd_opts.listen:
     # fix gradio phoning home


### PR DESCRIPTION
Currently AVIF images (added in https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/cde35bebe90f05d2fa481663775ce5bd32d7cdd7) will download, rather than open, as the default behaviour. Turns out we need to add it as a valid MIME type so it acts like other image types.

## Description
Simple change to `ui.py` to add `image/avif` as a valid MIME type, like `image/webp` currently is. Without this, AVIF images will be downloaded, rather than opened, by certain browsers (at least, that was the behaviour for Chrome 124.0.6367.119 on Windows 11.

## Screenshots/videos:

## Checklist:
- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)